### PR TITLE
feat: default to dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Community wiki for [goingdark.social](https://goingdark.social).
 Built with [Hugo](https://gohugo.io) and the Hugo Blox documentation theme.
+The site now loads in dark mode by default, and you can switch themes from the header.
 
 ## Local development
 

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -5,7 +5,7 @@
 
 # Appearance
 appearance:
-  mode: auto
+  mode: dark
   color: blue
 
 # SEO


### PR DESCRIPTION
## Summary
- default site appearance to dark theme
- document dark mode default in README

## Testing
- `hugo >/tmp/hugo.log && tail -n 20 /tmp/hugo.log`


------
https://chatgpt.com/codex/tasks/task_e_689e5e0409cc8322a62f2791461e933a