### PR TITLE
chore: add Vale lint workflow

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,14 @@
+name: Vale
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@v2
+        with:
+          config: .vale.ini

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+MinAlertLevel = warning
+Ignored = LICENSE.md, hugo-blox/**
+
+[*.md]
+BasedOnStyles = Vale
+TokenIgnores = Blox, blox, onboarding, Onboarding, Cushen, sublicense

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ hugo server
 
 The site will be served at `http://localhost:1313`.
 
+## Linting
+
+[Vale](https://vale.sh) checks the docs for style issues. Run `vale .` before committing. The workflow runs on each push and pull request.
+
 ## Deployment
 
 Commits to `main` deploy to GitHub Pages via the included workflow.


### PR DESCRIPTION
## Summary
- add Vale linting workflow for documentation
- note Vale usage in README

## Testing
- `vale . >/tmp/vale.log && tail -n 20 /tmp/vale.log`
- `hugo --minify >/tmp/hugo.log && tail -n 20 /tmp/hugo.log`


------
https://chatgpt.com/codex/tasks/task_e_689e5e3bc65483229cfaf2e3174a5d42