### PR TITLE
docs: add server policies and operations guides

### DIFF
--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -1,0 +1,21 @@
+---
+title: Privacy
+toc: true
+reading_time: false
+pager: false
+---
+
+We keep the minimum necessary data.
+
+### Logs
+
+- Access logs with IP addresses kept for 14 days.
+- Moderation logs retained for one year.
+- Backups encrypted at rest.
+
+Only administrators can access logs.
+
+### Data rights
+
+You may request, correct, or delete your data by emailing privacy@goingdark.social. We respond within 30 days.
+

--- a/content/docs/operations/backup-and-restore.md
+++ b/content/docs/operations/backup-and-restore.md
@@ -1,0 +1,26 @@
+---
+title: Backup and Restore
+toc: true
+reading_time: false
+pager: false
+---
+
+### What is backed up
+
+- PostgreSQL databases.
+- Redis snapshots.
+- Media stored in R2.
+- Configuration files.
+
+### Schedule and retention
+
+Daily encrypted backups retained for 30 days. Weekly backups kept for 6 months.
+
+### Restore
+
+Test restores run quarterly. Our target is to restore service within 4 hours of a failure.
+
+### Offsite copies
+
+Backups replicate to a separate R2 bucket and a physical drive held by the admin team. Credentials are stored in a hardware password vault.
+

--- a/content/docs/operations/hosting-architecture.md
+++ b/content/docs/operations/hosting-architecture.md
@@ -1,0 +1,19 @@
+---
+title: Hosting Architecture
+toc: true
+reading_time: false
+pager: false
+---
+
+goingdark.social runs on Talos-managed Kubernetes.
+
+- **Network:** Cilium with BGP advertising prefix 192.0.2.0/24. Load balancers expose 192.0.2.10.
+- **Ingress:** Kubernetes Gateway API behind Cloudflared tunnels.
+- **Storage:** Media files in R2 bucket `gds-media` (public). Backups in R2 bucket `gds-backups` (private).
+- **Database:** PostgreSQL with PgBouncer connection pooling.
+- **Cache and queues:** Redis.
+- **Search:** Elasticsearch.
+- **Backups:** Automated snapshots stored offsite.
+
+Public endpoints are the web interface and API. Internal services stay on private networks.
+

--- a/content/docs/operations/incidents.md
+++ b/content/docs/operations/incidents.md
@@ -1,0 +1,24 @@
+---
+title: Incidents
+toc: true
+reading_time: false
+pager: false
+---
+
+We monitor services and respond to outages as quickly as possible.
+
+### Communication
+
+- Status updates: https://status.goingdark.social/
+- Fallback: posts from @admin@goingdark.social
+- Email: contact@goingdark.social
+
+### Postmortem template
+
+1. Summary.
+2. Impact.
+3. Timeline.
+4. Root cause.
+5. Remediation.
+6. Action items.
+

--- a/content/docs/operations/shutdown-procedure.md
+++ b/content/docs/operations/shutdown-procedure.md
@@ -1,0 +1,32 @@
+---
+title: Shutdown Procedure
+toc: true
+reading_time: false
+pager: false
+---
+
+If we ever shut down:
+
+### Communication timeline
+
+- Two months: initial announcement.
+- One month: reminder.
+- Three weeks: instructions reposted.
+- Two weeks: final warning.
+- Final week: daily reminders.
+
+### Member steps
+
+- Export data.
+- Migrate account.
+- Set email forwarding.
+
+### Technical plan
+
+1. Close new signups.
+2. Enter read-only mode.
+3. Run `tootctl self-destruct`.
+4. Wait for federated deletes.
+5. Decommission hosting.
+6. Serve a static tombstone page.
+

--- a/content/docs/overview/about.md
+++ b/content/docs/overview/about.md
@@ -1,0 +1,23 @@
+---
+title: About
+toc: true
+reading_time: false
+pager: false
+---
+
+goingdark.social is a privacy-focused Mastodon server for friendly tech conversations.
+
+The service is run by Going Dark LLC, a small US-based company. The admin team works primarily in the UTC time zone.
+
+Contact: contact@goingdark.social  
+Abuse reports: abuse@goingdark.social  
+Support requests are normally answered within 72 hours.
+
+See also:
+
+- [Reporting](/docs/user/reporting/)
+- [Rules](/docs/policies/rules/)
+- [Moderation Guidelines](/docs/policies/moderation-guidelines/)
+- [Federation Policy](/docs/policies/federation-policy/)
+- [Migration Guide](/docs/user/migration/)
+

--- a/content/docs/overview/goals.md
+++ b/content/docs/overview/goals.md
@@ -1,0 +1,15 @@
+---
+title: Goals
+toc: true
+reading_time: false
+pager: false
+---
+
+Our mission is to provide a friendly, privacy-first space for people who enjoy technology.
+
+Who it's for: developers, admins, and curious folks who value respectful conversation.
+
+What it's not: a marketing platform, a data-mining service, or a free pass for harassment.
+
+Long term, we aim to keep the server small, sustainable, and community-funded while improving privacy tooling and fostering open source collaboration.
+

--- a/content/docs/policies/bots-and-automation.md
+++ b/content/docs/policies/bots-and-automation.md
@@ -1,0 +1,19 @@
+---
+title: Bots and Automation
+toc: true
+reading_time: false
+pager: false
+---
+
+Bots must clearly identify as automated in their profile and bio.
+
+Guidelines:
+
+- Post no more than 20 times per day.
+- Wait at least one minute between posts.
+- Provide alt text for all media.
+- Keep media under 8 MB per file.
+- Contact contact@goingdark.social before operating heavy bots.
+
+Violations may trigger rate limits or moderation actions such as silencing or suspension.
+

--- a/content/docs/policies/federation-policy.md
+++ b/content/docs/policies/federation-policy.md
@@ -1,0 +1,21 @@
+---
+title: Federation Policy
+toc: true
+reading_time: false
+pager: false
+---
+
+We federate with domains that respect privacy and basic conduct.
+
+Defederation is considered when:
+
+- Persistent spam or harassment.
+- Lack of moderation.
+- Technical abuse.
+
+Domains under review are listed in a temporary block list. Each block entry notes the domain, reason, and date.
+
+Blocks are reviewed monthly. A transparency log of changes is published in [Metrics](/docs/transparency/metrics/).
+
+Federation blocks only affect how content appears locally; remote servers remain unaffected.
+

--- a/content/docs/policies/moderation-guidelines.md
+++ b/content/docs/policies/moderation-guidelines.md
@@ -1,0 +1,32 @@
+---
+title: Moderation Guidelines
+toc: true
+reading_time: false
+pager: false
+---
+
+These guidelines cover moderation on goingdark.social. They apply to local accounts and content hosted here.
+
+### Actions
+
+- **Warn** – minor issue; user notified.
+- **Silence** – account visible only to followers.
+- **Suspend** – account access revoked.
+- **Limit** – post reach reduced.
+- **Domain block** – remote server hidden.
+- **Account deletion** – data removed after self-destruct.
+
+Email notifications are sent for each action.
+
+### Behaviour mapping
+
+- Spam or mass advertisement – limit or suspend.
+- Harassment or hate – warn then suspend or delete.
+- Illegal content – suspend and report.
+- Bot abuse – silence or suspend.
+- Malicious domains – domain block.
+
+### Appeals
+
+One appeal may be filed within 14 days by emailing contact@goingdark.social. We answer within 14 days. Decisions after the appeal are final.
+

--- a/content/docs/policies/rules.md
+++ b/content/docs/policies/rules.md
@@ -1,0 +1,18 @@
+---
+title: Rules
+toc: true
+reading_time: false
+pager: false
+---
+
+- Treat people well.
+- Use content warnings when a post might upset or surprise others.
+- Keep public areas safe for work.
+- No illegal content or solicitations.
+- No spam or automated promotion.
+- No hate, threats, or harassment.
+- Don't game the rules or look for loopholes.
+- Be honest about who you are.
+
+Breaking rules may lead to moderation action. Appeals are handled as described in our [Moderation Guidelines](/docs/policies/moderation-guidelines/#appeals).
+

--- a/content/docs/transparency/metrics.md
+++ b/content/docs/transparency/metrics.md
@@ -1,0 +1,16 @@
+---
+title: Metrics
+toc: true
+reading_time: false
+pager: false
+---
+
+We publish monthly counts for:
+
+- Active users.
+- New signups.
+- Reports handled.
+- Moderation actions.
+- Federation changes.
+- Incidents.
+

--- a/content/docs/user/migration.md
+++ b/content/docs/user/migration.md
@@ -1,0 +1,34 @@
+---
+title: Migration
+toc: true
+reading_time: false
+pager: false
+---
+
+You can move to or from goingdark.social at any time.
+
+### Moving here
+
+1. Create an account on goingdark.social.
+2. In your old account's settings, set this server as your new home.
+3. Confirm the move; followers will transfer.
+
+### Moving away
+
+1. Create an account on your new server.
+2. In goingdark.social settings, set the new account as the destination.
+3. Export your data and confirm.
+
+### What migrates
+
+- Followers and followings.
+- Block and mute lists.
+- Profile fields.
+
+### What does not
+
+- Posts and media.
+- Direct messages.
+
+Transfers usually complete within a few minutes, but large accounts may take up to a day.
+

--- a/content/docs/user/reporting.md
+++ b/content/docs/user/reporting.md
@@ -1,0 +1,29 @@
+---
+title: Reporting
+toc: true
+reading_time: false
+pager: false
+---
+
+### From the web
+
+1. Open the post or profile.
+2. Use the **Report** option.
+3. Add notes or attach posts.
+
+### From apps
+
+Most apps offer a **Report** button in the post menu. Include as much context as possible.
+
+### Helpful info
+
+- Links to offending posts.
+- Screenshots for disappearing content.
+- Why it violates rules.
+
+### After you report
+
+Moderators review reports within 48 hours and may contact you for details. You will receive a notification when the case is closed.
+
+Abuse inbox: abuse@goingdark.social.
+


### PR DESCRIPTION
## Summary
- add about and goals pages for goingdark.social
- document rules, moderation, federation, and bot policies
- add user, operations, transparency, and privacy guides

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689e5f301a68832294fce0a8bc872bb1