### PR TITLE
docs: add section index pages

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,4 +3,4 @@ Ignored = LICENSE.md, hugo-blox/**
 
 [*.md]
 BasedOnStyles = Vale
-TokenIgnores = Blox, blox, onboarding, Onboarding, Cushen, sublicense
+TokenIgnores = Blox, blox, onboarding, Onboarding, Cushen, sublicense, Cloudflared, signups, Defederation

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -7,8 +7,14 @@ Welcome to the goingdark.social wiki.
 
 This space contains rules, onboarding, federation policy, moderation notes, and FAQs for our community.
 
-## Next
+## Sections
 
 {{< cards >}}
+  {{< card url="overview/" title="Overview" >}}
+  {{< card url="policies/" title="Policies" >}}
+  {{< card url="operations/" title="Operations" >}}
+  {{< card url="transparency/" title="Transparency" >}}
+  {{< card url="user/" title="User guides" >}}
+  {{< card url="legal/" title="Legal" >}}
   {{< card url="../community" title="Community" icon="users" subtitle="Contact and contribution" >}}
 {{< /cards >}}

--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -1,0 +1,4 @@
+---
+title: Legal
+weight: 60
+---

--- a/content/docs/operations/_index.md
+++ b/content/docs/operations/_index.md
@@ -1,0 +1,4 @@
+---
+title: Operations
+weight: 30
+---

--- a/content/docs/overview/_index.md
+++ b/content/docs/overview/_index.md
@@ -1,0 +1,4 @@
+---
+title: Overview
+weight: 10
+---

--- a/content/docs/policies/_index.md
+++ b/content/docs/policies/_index.md
@@ -1,0 +1,4 @@
+---
+title: Policies
+weight: 20
+---

--- a/content/docs/transparency/_index.md
+++ b/content/docs/transparency/_index.md
@@ -1,0 +1,4 @@
+---
+title: Transparency
+weight: 40
+---

--- a/content/docs/user/_index.md
+++ b/content/docs/user/_index.md
@@ -1,0 +1,4 @@
+---
+title: User guides
+weight: 50
+---


### PR DESCRIPTION
## Summary
- list all docs sections on landing page for easier navigation
- add index pages for each docs section
- ignore domain-specific words in Vale

## Testing
- `vale .`
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_689e62c077ec8322bf1b24e48342e854