### PR TITLE
fix: hide Hugo Blox footer attribution

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -3,6 +3,8 @@
 # Documentation: https://docs.hugoblox.com/
 # This file is formatted using YAML syntax - learn more at https://learnxinyminutes.com/docs/yaml/
 
+i_am_a_sponsor: true
+
 # Appearance
 appearance:
   mode: dark


### PR DESCRIPTION
## Summary
- hide Hugo Blox Builder tagline in site footer

## Testing
- `hugo`
- `vale .`


------
https://chatgpt.com/codex/tasks/task_e_689e677a00f48322b66f0739a7027354