### PR TITLE
fix: point help requests to wiki discussions

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -70,8 +70,8 @@ features:
     branch: 'main'
   feedback:
     responses:
-      positive: 'Useful? Open an issue or PR.'
-      negative: 'Missing or wrong? Open an issue with details.'
+      positive: 'Useful? Start a discussion.'
+      negative: 'Missing or wrong? Start a discussion with details.'
   comment:
     provider: ''
     giscus:

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -9,8 +9,7 @@ pager: false
 Home: https://goingdark.social/
 
 ## Get help
-- Open an issue or PR: https://github.com/goingdark-social/wiki
-- Email: contact@goingdark.social
+- Start a discussion: https://github.com/goingdark-social/wiki/discussions
 
 ## What to contribute
 - Onboarding tips for new users


### PR DESCRIPTION
## Summary
- direct readers to wiki Discussions instead of issues or email
- update feedback prompts to invite Discussions

## Testing
- `vale .`
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689e670966588322a3a2321fb9c7dbb6