### PR TITLE
docs: add weights and navigation links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,7 @@
 title: 'Home'
 date: 2023-10-24
 type: landing
+weight: 1
 
 design:
   # Default section spacing

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,4 +1,5 @@
 ---
+weight: 30
 _build:
   render: never
 ---

--- a/content/community/index.md
+++ b/content/community/index.md
@@ -1,5 +1,6 @@
 ---
 title: Community
+weight: 20
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,6 +1,7 @@
 ---
 linkTitle: Documentation
 title: Introduction
+weight: 10
 ---
 
 Welcome to the goingdark.social wiki.

--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -2,3 +2,6 @@
 title: Legal
 weight: 60
 ---
+
+- [Privacy](privacy/)
+

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -1,5 +1,6 @@
 ---
 title: Privacy
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/operations/_index.md
+++ b/content/docs/operations/_index.md
@@ -2,3 +2,9 @@
 title: Operations
 weight: 30
 ---
+
+- [Backup and restore](backup-and-restore/)
+- [Hosting architecture](hosting-architecture/)
+- [Incidents](incidents/)
+- [Shutdown procedure](shutdown-procedure/)
+

--- a/content/docs/operations/backup-and-restore.md
+++ b/content/docs/operations/backup-and-restore.md
@@ -1,5 +1,6 @@
 ---
 title: Backup and Restore
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/operations/hosting-architecture.md
+++ b/content/docs/operations/hosting-architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Hosting Architecture
+weight: 20
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/operations/incidents.md
+++ b/content/docs/operations/incidents.md
@@ -1,5 +1,6 @@
 ---
 title: Incidents
+weight: 30
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/operations/shutdown-procedure.md
+++ b/content/docs/operations/shutdown-procedure.md
@@ -1,5 +1,6 @@
 ---
 title: Shutdown Procedure
+weight: 40
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/overview/_index.md
+++ b/content/docs/overview/_index.md
@@ -2,3 +2,7 @@
 title: Overview
 weight: 10
 ---
+
+- [About](about/)
+- [Goals](goals/)
+

--- a/content/docs/overview/about.md
+++ b/content/docs/overview/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/overview/goals.md
+++ b/content/docs/overview/goals.md
@@ -1,5 +1,6 @@
 ---
 title: Goals
+weight: 20
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/policies/_index.md
+++ b/content/docs/policies/_index.md
@@ -2,3 +2,9 @@
 title: Policies
 weight: 20
 ---
+
+- [Bots and automation](bots-and-automation/)
+- [Federation policy](federation-policy/)
+- [Moderation guidelines](moderation-guidelines/)
+- [Rules](rules/)
+

--- a/content/docs/policies/bots-and-automation.md
+++ b/content/docs/policies/bots-and-automation.md
@@ -1,5 +1,6 @@
 ---
 title: Bots and Automation
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/policies/federation-policy.md
+++ b/content/docs/policies/federation-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Federation Policy
+weight: 20
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/policies/moderation-guidelines.md
+++ b/content/docs/policies/moderation-guidelines.md
@@ -1,5 +1,6 @@
 ---
 title: Moderation Guidelines
+weight: 30
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/policies/rules.md
+++ b/content/docs/policies/rules.md
@@ -1,5 +1,6 @@
 ---
 title: Rules
+weight: 40
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/transparency/_index.md
+++ b/content/docs/transparency/_index.md
@@ -2,3 +2,6 @@
 title: Transparency
 weight: 40
 ---
+
+- [Metrics](metrics/)
+

--- a/content/docs/transparency/metrics.md
+++ b/content/docs/transparency/metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/user/_index.md
+++ b/content/docs/user/_index.md
@@ -2,3 +2,7 @@
 title: User guides
 weight: 50
 ---
+
+- [Migration](migration/)
+- [Reporting](reporting/)
+

--- a/content/docs/user/migration.md
+++ b/content/docs/user/migration.md
@@ -1,5 +1,6 @@
 ---
 title: Migration
+weight: 10
 toc: true
 reading_time: false
 pager: false

--- a/content/docs/user/reporting.md
+++ b/content/docs/user/reporting.md
@@ -1,5 +1,6 @@
 ---
 title: Reporting
+weight: 20
 toc: true
 reading_time: false
 pager: false


### PR DESCRIPTION
## Summary
- add weight metadata across site pages
- link each section index to its child pages

## Testing
- `hugo --minify`
- `vale .`


------
https://chatgpt.com/codex/tasks/task_e_689e674103a883228a2bae2b5de71d1f