### PR TITLE
docs: add funding page and link to ko-fi

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ The site will be served at `http://localhost:1313`.
 
 Commits to `main` deploy to GitHub Pages via the included workflow.
 
+## Funding
+
+The server runs at home and the costs come out of pocket. Help keep it running at <https://ko-fi.com/goingdark>.
+

--- a/content/docs/overview/about.md
+++ b/content/docs/overview/about.md
@@ -7,9 +7,12 @@ pager: false
 
 goingdark.social is a privacy-focused Mastodon server for friendly tech conversations.
 
+
 The service is run by Going Dark LLC, a small US-based company. The admin team works primarily in the UTC time zone.
 
-Contact: contact@goingdark.social  
+Right now the server runs at home and is funded out of pocket. Help keep it running at [Ko-fi](https://ko-fi.com/goingdark).
+
+Contact: contact@goingdark.social
 Abuse reports: abuse@goingdark.social  
 Support requests are normally answered within 72 hours.
 
@@ -19,5 +22,6 @@ See also:
 - [Rules](/docs/policies/rules/)
 - [Moderation Guidelines](/docs/policies/moderation-guidelines/)
 - [Federation Policy](/docs/policies/federation-policy/)
+- [Funding](/docs/overview/funding/)
 - [Migration Guide](/docs/user/migration/)
 

--- a/content/docs/overview/funding.md
+++ b/content/docs/overview/funding.md
@@ -1,0 +1,12 @@
+---
+title: Funding
+toc: true
+reading_time: false
+pager: false
+---
+
+The server runs on home hardware and the bills are paid out of pocket. To keep the instance sustainable and make sure it doesn't vanish, we want hosting costs covered by the community.
+
+If you'd like to help keep the lights on, chip in at [Ko-fi](https://ko-fi.com/goingdark).
+
+Every donation brings us closer to not footing the bill alone.

--- a/content/docs/overview/goals.md
+++ b/content/docs/overview/goals.md
@@ -11,5 +11,5 @@ Who it's for: developers, admins, and curious folks who value respectful convers
 
 What it's not: a marketing platform, a data-mining service, or a free pass for harassment.
 
-Long term, we aim to keep the server small, sustainable, and community-funded while improving privacy tooling and fostering open source collaboration.
+Long term, we aim to keep the server small, sustainable, and community-funded. It's running at home and funded out of pocket today. Covering the costs through [Ko-fi](https://ko-fi.com/goingdark) lets everyone trust the instance will stick around.
 


### PR DESCRIPTION
## Summary
- add standalone funding page
- link to Ko-fi across overview docs and README

## Testing
- `vale .`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689e6907fc248322bb2901b314453f4a