### PR TITLE
chore: expand Vale packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 resources/
 public/
 jsconfig.json
+.vale/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,8 @@
 MinAlertLevel = warning
+StylesPath = .vale
+Packages = write-good, Microsoft, Google
 Ignored = LICENSE.md, hugo-blox/**
 
 [*.md]
-BasedOnStyles = Vale
+BasedOnStyles = Vale, write-good
 TokenIgnores = Blox, blox, onboarding, Onboarding, Cushen, sublicense, Cloudflared, signups, Defederation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The site will be served at `http://localhost:1313`.
 
 ## Linting
 
-[Vale](https://vale.sh) checks the docs for style issues. Run `vale .` before committing. The workflow runs on each push and pull request.
+[Vale](https://vale.sh) checks the docs for style issues using the Write Good guidelines. Run `vale sync` once to download the Write Good, Microsoft, and Google packages, then `vale .` before committing. The workflow runs on each push and pull request.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- enable Write Good, Microsoft, and Google packages for Vale
- ignore the downloaded styles directory
- document the new Vale packages and sync step

## Testing
- `vale .`


------
https://chatgpt.com/codex/tasks/task_e_689e6a536e7883228ae92aa66ce22965