### PR TITLE
fix: use root-relative community URLs

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -9,7 +9,7 @@ main:
     url: /docs/
     weight: 20
   - name: Community
-    url: community/
+    url: /community/
     weight: 30
 
 sidebar:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -17,5 +17,5 @@ This space contains rules, onboarding, federation policy, moderation notes, and 
   {{< card url="transparency/" title="Transparency" icon="eye" subtitle="Reports and decision logs" >}}
   {{< card url="user/" title="User guides" icon="book-open" subtitle="How to get started" >}}
   {{< card url="legal/" title="Legal" icon="scale" subtitle="Terms and compliance" >}}
-  {{< card url="../community" title="Community" icon="users" subtitle="Contact and contribution" >}}
+  {{< card url="/community/" title="Community" icon="users" subtitle="Contact and contribution" >}}
 {{< /cards >}}


### PR DESCRIPTION
## Summary
- use root-relative URL for Community menu entry
- update Community card link to root-relative path

## Testing
- `vale .`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689e6b24d42c832292d418a457150336