### PR TITLE
docs: add sidebar sections

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -13,12 +13,24 @@ main:
     weight: 30
 
 sidebar:
+  - identifier: overview
+    name: Overview
+    pageRef: "/docs/overview"
+    weight: 1
+  - identifier: policies
+    name: Policies
+    pageRef: "/docs/policies"
+    weight: 2
+  - identifier: operations
+    name: Operations
+    pageRef: "/docs/operations"
+    weight: 3
   - identifier: more
     name: Need help?
     params:
       type: separator
-    weight: 1
+    weight: 90
   - identifier: community
     name: "Community"
     pageRef: "/community"
-    weight: 2
+    weight: 100


### PR DESCRIPTION
## Summary
- add Overview, Policies, and Operations to docs sidebar
- order menu items with weights for consistent display

## Testing
- `hugo --minify`
- `grep -o 'href=/docs/overview/' public/docs/index.html | head -n 20`
- `grep -o 'href=/docs/policies/' public/docs/overview/index.html | head -n 20`
- `grep -o 'href=/docs/overview/' public/docs/operations/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689e6b2c02788322ac8ff53832813f16