### PR TITLE
docs: use card layout for section indexes

### DIFF
--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -2,6 +2,7 @@
 title: Legal
 weight: 60
 ---
-
-- [Privacy](privacy/)
+{{< cards >}}
+  {{< card url="privacy/" title="Privacy" icon="lock-closed" subtitle="What data we collect and how long we keep it" >}}
+{{< /cards >}}
 

--- a/content/docs/operations/_index.md
+++ b/content/docs/operations/_index.md
@@ -2,9 +2,10 @@
 title: Operations
 weight: 30
 ---
-
-- [Backup and restore](backup-and-restore/)
-- [Hosting architecture](hosting-architecture/)
-- [Incidents](incidents/)
-- [Shutdown procedure](shutdown-procedure/)
+{{< cards >}}
+  {{< card url="backup-and-restore/" title="Backup and restore" icon="arrow-path" subtitle="How we back up and recover systems" >}}
+  {{< card url="hosting-architecture/" title="Hosting architecture" icon="server-stack" subtitle="Infrastructure layout and components" >}}
+  {{< card url="incidents/" title="Incidents" icon="bolt" subtitle="How we handle outages and status updates" >}}
+  {{< card url="shutdown-procedure/" title="Shutdown procedure" icon="power" subtitle="Steps if the service shuts down" >}}
+{{< /cards >}}
 

--- a/content/docs/overview/_index.md
+++ b/content/docs/overview/_index.md
@@ -2,7 +2,8 @@
 title: Overview
 weight: 10
 ---
-
-- [About](about/)
-- [Goals](goals/)
+{{< cards >}}
+  {{< card url="about/" title="About" icon="information-circle" subtitle="What goingdark.social is and who's behind it" >}}
+  {{< card url="goals/" title="Goals" icon="flag" subtitle="Why the project exists and who it's for" >}}
+{{< /cards >}}
 

--- a/content/docs/policies/_index.md
+++ b/content/docs/policies/_index.md
@@ -2,9 +2,10 @@
 title: Policies
 weight: 20
 ---
-
-- [Bots and automation](bots-and-automation/)
-- [Federation policy](federation-policy/)
-- [Moderation guidelines](moderation-guidelines/)
-- [Rules](rules/)
+{{< cards >}}
+  {{< card url="bots-and-automation/" title="Bots and automation" icon="bug-ant" subtitle="Rules for automated accounts" >}}
+  {{< card url="federation-policy/" title="Federation policy" icon="globe-alt" subtitle="How we choose who to federate with" >}}
+  {{< card url="moderation-guidelines/" title="Moderation guidelines" icon="hand-raised" subtitle="How moderation decisions are made" >}}
+  {{< card url="rules/" title="Rules" icon="clipboard-document-check" subtitle="Code of conduct for the community" >}}
+{{< /cards >}}
 

--- a/content/docs/transparency/_index.md
+++ b/content/docs/transparency/_index.md
@@ -2,6 +2,7 @@
 title: Transparency
 weight: 40
 ---
-
-- [Metrics](metrics/)
+{{< cards >}}
+  {{< card url="metrics/" title="Metrics" icon="chart-bar" subtitle="Monthly transparency figures" >}}
+{{< /cards >}}
 

--- a/content/docs/user/_index.md
+++ b/content/docs/user/_index.md
@@ -2,7 +2,8 @@
 title: User guides
 weight: 50
 ---
-
-- [Migration](migration/)
-- [Reporting](reporting/)
+{{< cards >}}
+  {{< card url="migration/" title="Migration" icon="arrow-right-on-rectangle" subtitle="How to move your account between servers" >}}
+  {{< card url="reporting/" title="Reporting" icon="flag" subtitle="How to report problems to moderators" >}}
+{{< /cards >}}
 


### PR DESCRIPTION
## Summary
- replace section link lists with cards featuring icons and descriptions

## Testing
- `hugo --minify` *(fails: Module "github.com/HugoBlox/hugo-blox-builder/modules/blox-tailwind" is not compatible with this Hugo version)*

------
https://chatgpt.com/codex/tasks/task_e_689e6b7130f8832287f41765f91482a0